### PR TITLE
Update executivesummary_preproc.sh

### DIFF
--- a/executivesummary_preproc.sh
+++ b/executivesummary_preproc.sh
@@ -500,7 +500,9 @@ if [[ -e ${t2_2_brain_img} ]] ; then
 fi
 
 # Make T1w and T2w task images.
-for TASK in `ls -d ${Results}/*task-*` ; do
+
+# ending slash in "*task-*/" is required to ensure ls -d gets only dirnames
+for TASK in `ls -d ${Results}/*task-*/` ; do
     fMRIName=$( basename ${TASK} )
     echo Make images for ${fMRIName}.
     task_img="${Results}/${fMRIName}/${fMRIName}.nii.gz"


### PR DESCRIPTION
The ls -d command used to get task dirnames within the Results dir for task-image creation was (seemingly) unintentionally also getting the task timeseries filenames, though the images would still be made successfully so long as a dirname was the first result gotten by ls -d.